### PR TITLE
fix: setLogger return type must match interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## 4.0.0
 
-- Add support for PHP 8
+- Add support for PHP 8.0, 8.1, 8.2
+
+### Breaking Changes
+
+- Drop support for php 7.2 and 7.3
+- setLogger no longer returns self (now returns void) to match interface
 
 ## 3.0.0
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -402,11 +402,9 @@ class Client implements LoggerAwareInterface
      *
      * @return $this
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
-
-        return $this;
     }
 
     /**
@@ -559,7 +557,7 @@ class Client implements LoggerAwareInterface
      * @param       $message
      * @param array $context
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->getLogger()->log($level, $message, $context);
     }

--- a/tests/Unit/HyperTest.php
+++ b/tests/Unit/HyperTest.php
@@ -149,7 +149,9 @@ class HyperTest extends TestCase
 
     public function test_fluent_initialisation()
     {
-        $hyper = Hyper::make()->setBaseUri('http://example.com/v1')->setLogger(new NullLogger())->setGuzzleClient(new GuzzleClient());
+        $hyper = Hyper::make()->setBaseUri('http://example.com/v1')
+            ->setGuzzleClient(new GuzzleClient());
+        $hyper->setLogger(new NullLogger());
         $this->assertEquals('http://example.com/v1', $hyper->getBaseUri());
         $this->assertInstanceOf(NullLogger::class, $hyper->getLogger());
         $this->assertInstanceOf(GuzzleClient::class, $hyper->getGuzzleClient());

--- a/tests/Unit/Logging/LogFormatTest.php
+++ b/tests/Unit/Logging/LogFormatTest.php
@@ -32,7 +32,7 @@ class LogFormatTest extends TestCase
         return new class() extends AbstractLogger {
             public $messages = [];
 
-            public function log($level, $message, array $context = [])
+            public function log($level, $message, array $context = []): void
             {
                 $this->messages[] = $message;
             }


### PR DESCRIPTION
# Overview

Ran into issues while dealing with phoenix hyper

* setLogger no longer returns self (now returns void) to match interface

# After merge

* Re-release as 4.0.0.